### PR TITLE
Fixed counter ignores self-closing elements.

### DIFF
--- a/src/XPathReader/XPathReader.Tests/Smoke Tests/XPathReaderTests.cs
+++ b/src/XPathReader/XPathReader.Tests/Smoke Tests/XPathReaderTests.cs
@@ -179,6 +179,8 @@ namespace ARTX.XPathReader.Tests.Smoke_Tests
             {
                 testCancellationToken.ThrowIfCancellationRequested();
                 elements.Add(result.NodeReader.ReadOuterXml());
+
+                Assert.That(result.ActualXPath.GetXPath(), Is.EqualTo($"/a/b[2]/c[{elements.Count}]"));
             }
             Assert.That(elements, Has.Count.EqualTo(2));
             Assert.That(elements[0], Is.EqualTo("<c />"));

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -53,9 +53,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -68,9 +67,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -127,9 +125,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -142,9 +139,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -50,9 +50,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -65,9 +64,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -124,9 +122,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -139,9 +136,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_partial_record_classpublic_static_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -53,9 +53,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -68,9 +67,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -127,9 +125,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -142,9 +139,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -50,9 +50,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -65,9 +64,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -124,9 +122,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -139,9 +136,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.internal_ref_partial_structpublic_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -53,9 +53,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -68,9 +67,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -127,9 +125,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -142,9 +139,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -50,9 +50,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -65,9 +64,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -124,9 +122,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -139,9 +136,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.partial_interfaceinternal_static_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -53,9 +53,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -68,9 +67,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -127,9 +125,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -142,9 +139,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -50,9 +50,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -65,9 +64,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -124,9 +122,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -139,9 +136,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_classpublic_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -53,9 +53,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -68,9 +67,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -127,9 +125,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -142,9 +139,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -50,9 +50,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -65,9 +64,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -124,9 +122,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -139,9 +136,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_recordprivate_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -53,9 +53,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -68,9 +67,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -127,9 +125,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -142,9 +139,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -50,9 +50,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -65,9 +64,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -124,9 +122,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -139,9 +136,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_partial_structprotected_internal_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -53,9 +53,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -68,9 +67,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -127,9 +125,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -142,9 +139,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_ForProperty_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -60,9 +60,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -78,9 +77,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -92,9 +90,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -106,9 +103,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -120,9 +116,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -131,9 +126,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -210,9 +204,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -228,9 +221,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -244,9 +236,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -260,9 +251,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -276,9 +266,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -287,9 +276,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_NoErrors(Normal_method)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_NoErrors(Normal_method_duplicates)__#TestClass_0.g.verified.cs
@@ -50,9 +50,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -65,9 +64,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         
@@ -124,9 +122,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -139,9 +136,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000004 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000003);
                                         

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_NoErrors(Normal_method_predicates)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
+++ b/src/XPathReader/XPathReader.Tests/XPathReaderGeneratorTests.public_readonly_ref_partial_structprivate_protected_static_GeneratesXPathReader_NoErrors(Normal_method_with_new_line)__#TestClass_0.g.verified.cs
@@ -57,9 +57,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -75,9 +74,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -89,9 +87,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -103,9 +100,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -117,9 +113,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -128,9 +123,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     
@@ -207,9 +201,8 @@ namespace ARTX.XPath.Generated
                     
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        if ((ReferenceEquals(reader.LocalName, e_root)) && !reader.IsEmptyElement)
+                        if ((ReferenceEquals(reader.LocalName, e_root)) && ++counter00000001 == counter00000001 && !reader.IsEmptyElement)
                         {
-                            ++counter00000001;
                             int originalLength00000002 = currentXPathBuilder.Length;
                             currentXPathBuilder.AddLevel("root");
                             if (counter00000001 != 1)
@@ -225,9 +218,8 @@ namespace ARTX.XPath.Generated
                             {
                                 if (reader.NodeType == XmlNodeType.Element)
                                 {
-                                    if ((ReferenceEquals(reader.LocalName, e_child1)))
+                                    if ((ReferenceEquals(reader.LocalName, e_child1)) && ++counter00000003 == counter00000003)
                                     {
-                                        ++counter00000003;
                                         int originalLength00000007 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child1", counter00000003);
                                         
@@ -241,9 +233,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000007;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child)) && ++counter00000004 == counter00000004)
                                     {
-                                        ++counter00000004;
                                         int originalLength00000008 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child", counter00000004);
                                         
@@ -257,9 +248,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000008;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)))
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_important)) && ++counter00000005 == counter00000005)
                                     {
-                                        ++counter00000005;
                                         int originalLength00000009 = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child.important", counter00000005);
                                         
@@ -273,9 +263,8 @@ namespace ARTX.XPath.Generated
                                         
                                         currentXPathBuilder.Length = originalLength00000009;
                                     }
-                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && !reader.IsEmptyElement)
+                                    else if ((ReferenceEquals(reader.LocalName, e_child_3)) && ++counter00000006 == counter00000006 && !reader.IsEmptyElement)
                                     {
-                                        ++counter00000006;
                                         int originalLength0000000a = currentXPathBuilder.Length;
                                         currentXPathBuilder.AddLevel("child-3", counter00000006);
                                         int counter0000000b = 0;
@@ -284,9 +273,8 @@ namespace ARTX.XPath.Generated
                                         {
                                             if (reader.NodeType == XmlNodeType.Element)
                                             {
-                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)))
+                                                if ((ReferenceEquals(reader.LocalName, e_grandchild1)) && ++counter0000000b == counter0000000b)
                                                 {
-                                                    ++counter0000000b;
                                                     int originalLength0000000c = currentXPathBuilder.Length;
                                                     currentXPathBuilder.AddLevel("grandchild1", counter0000000b);
                                                     

--- a/src/XPathReader/XPathReader/ReadXmlEmitter.cs
+++ b/src/XPathReader/XPathReader/ReadXmlEmitter.cs
@@ -94,11 +94,12 @@ namespace ARTX.XPathReader
                 // If we are not in the leaf, we do not care about empty elements.
                 bool checkForEmptyElement = !group.OfType<XPathTreeLeafElement>().Any();
 
+
+                // including increment of the counter in the if condition to avoid extra condition statements inside.
                 writer.WriteLine(
-                    $"{(i == 0 ? "" : "else ")}if ((ReferenceEquals(reader.LocalName, {_variableStorage[group.Key.LocalName]})){(checkForEmptyElement ? " && !reader.IsEmptyElement" : "")})");
+                    $"{(i == 0 ? "" : "else ")}if ((ReferenceEquals(reader.LocalName, {_variableStorage[group.Key.LocalName]})) && ++{counterVariables[index]} == {counterVariables[index]}{(checkForEmptyElement ? " && !reader.IsEmptyElement" : "")})");
                 writer.OpenBrace();
 
-                writer.WriteLine($"++{counterVariables[index]};");
                 writer.WriteLine($"int {originalLengthVariableName} = {NameOfTheXPathBuilder}.Length;");
 
                 if (isRoot)


### PR DESCRIPTION
Fixed counter ignores self-closing elements. To do that, indexer was moved to the if statement.